### PR TITLE
configure lefthook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,44 @@
+templates:
+  run: run --no-sync
+
+pre-commit:
+  parallel: true
+  skip:
+    - merge
+    - rebase
+  jobs:
+    - name: uv lock
+      glob: pyproject.toml
+      stage_fixed: true
+      run: uv lock
+
+    - name: dprint
+      glob: "*.{json,jsonc,md,toml,yaml,yml}"
+      stage_fixed: true
+      run: uv {run} dprint fmt --incremental=false
+
+    - name: ruff
+      glob: "*.{py,pyi}"
+      stage_fixed: true
+      group:
+        piped: true
+        jobs:
+          - name: check
+            run: uv {run} ruff check --fix {staged_files}
+          - name: format
+            run: uv {run} ruff format --quiet {staged_files}
+
+    - name: pyrefly
+      glob: "*.{py,pyi}"
+      run: uv {run} pyrefly check {staged_files}
+
+post-checkout:
+  jobs:
+    - run: uv sync
+      glob: uv.lock
+
+post-merge:
+  files: "git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD"
+  jobs:
+    - run: uv sync
+      glob: uv.lock


### PR DESCRIPTION
I prefer [lefthook](https://github.com/evilmartians/lefthook) over [prek](https://github.com/j178/prek), and have been happily using it in many of of projects for a while now.

Use `uv tool install lefthook --upgrade` to install, then run `uvx lefthook install` in the typestats root to initialize the commit hooks.