### PR TITLE
support for direct implicit re-exports

### DIFF
--- a/src/typestats/analyze.py
+++ b/src/typestats/analyze.py
@@ -565,10 +565,19 @@ def collect_global_symbols(source: str, /) -> ModuleSymbols:
         for obj, alias in aliases
     })
     reexports = frozenset(
-        name
-        for aliases in imports_visitor.alias_mapping.values()
-        for name, alias in aliases
-        if name == alias
+        [
+            *(
+                name
+                for aliases in imports_visitor.alias_mapping.values()
+                for name, alias in aliases
+                if name == alias
+            ),
+            *(
+                module
+                for module, alias in imports_visitor.module_aliases.items()
+                if module == alias
+            ),
+        ],
     )
 
     return ModuleSymbols(

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -1,7 +1,5 @@
 import textwrap
 
-import pytest
-
 from typestats.analyze import collect_global_symbols
 
 
@@ -21,7 +19,6 @@ def test_imports() -> None:
     assert imports["b.e"] == "_e"
 
 
-@pytest.mark.skip(reason="pending implementation")
 def test_exports_implicit_direct() -> None:
     src = textwrap.dedent("""
     import a


### PR DESCRIPTION
of the form `import a as a`