### PR TITLE
prefer `.pyi` when following imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ test = [
   "public-project",
   "private-reexport",
   "private-reexport-pyi",
+  "stub-typed-private",
 ]
 dev = [
   { include-group = "test" },
@@ -51,12 +52,14 @@ dev = [
 public-project = { workspace = true }
 private-reexport = { workspace = true }
 private-reexport-pyi = { workspace = true }
+stub-typed-private = { workspace = true }
 
 [tool.uv.workspace]
 members = [
   "tests/fixtures/public_project",
   "tests/fixtures/private_reexport",
   "tests/fixtures/private_reexport_pyi",
+  "tests/fixtures/stub_typed_private",
 ]
 
 # pytest

--- a/tests/fixtures/stub_typed_private/pyproject.toml
+++ b/tests/fixtures/stub_typed_private/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["uv_build<1.0"]
+build-backend = "uv_build"
+
+[tool.uv.build-backend]
+module-root = ""
+module-name = ["stubpkg"]
+
+[project]
+name = "stub-typed-private"
+version = "0.1.0"
+requires-python = ">=3.14"

--- a/tests/fixtures/stub_typed_private/stubpkg/__init__.py
+++ b/tests/fixtures/stub_typed_private/stubpkg/__init__.py
@@ -1,0 +1,3 @@
+from ._typeforms import AnnotatedAlias, GenericType
+
+__all__ = ["AnnotatedAlias", "GenericType"]

--- a/tests/fixtures/stub_typed_private/stubpkg/_typeforms.py
+++ b/tests/fixtures/stub_typed_private/stubpkg/_typeforms.py
@@ -1,0 +1,3 @@
+# No type annotations here; types are provided by .pyi stub
+AnnotatedAlias = type("AnnotatedAlias", (), {})
+GenericType = type("GenericType", (), {})

--- a/tests/fixtures/stub_typed_private/stubpkg/_typeforms.pyi
+++ b/tests/fixtures/stub_typed_private/stubpkg/_typeforms.pyi
@@ -1,0 +1,4 @@
+import typing
+
+AnnotatedAlias: typing.TypeAlias = type
+GenericType: typing.TypeAlias = type

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,7 @@ members = [
     "private-reexport",
     "private-reexport-pyi",
     "public-project",
+    "stub-typed-private",
     "typestats",
 ]
 
@@ -389,6 +390,11 @@ wheels = [
 ]
 
 [[package]]
+name = "stub-typed-private"
+version = "0.1.0"
+source = { editable = "tests/fixtures/stub_typed_private" }
+
+[[package]]
 name = "typestats"
 version = "0.0.0.dev0"
 source = { editable = "." }
@@ -411,12 +417,14 @@ dev = [
     { name = "pyrefly" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "stub-typed-private" },
 ]
 test = [
     { name = "private-reexport" },
     { name = "private-reexport-pyi" },
     { name = "public-project" },
     { name = "pytest" },
+    { name = "stub-typed-private" },
 ]
 
 [package.metadata]
@@ -439,12 +447,14 @@ dev = [
     { name = "pyrefly", specifier = ">=0.51.1" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "ruff", specifier = ">=0.15.0" },
+    { name = "stub-typed-private", editable = "tests/fixtures/stub_typed_private" },
 ]
 test = [
     { name = "private-reexport", editable = "tests/fixtures/private_reexport" },
     { name = "private-reexport-pyi", editable = "tests/fixtures/private_reexport_pyi" },
     { name = "public-project", editable = "tests/fixtures/public_project" },
     { name = "pytest", specifier = ">=9.0.2" },
+    { name = "stub-typed-private", editable = "tests/fixtures/stub_typed_private" },
 ]
 
 [[package]]


### PR DESCRIPTION
the `optype/types/__init__.py` re-exports will now correctly use the `.pyi` types, rather than the (missing) ones from the `.py`