### PR TITLE
support "direct" aliases like `A = B`

### DIFF
--- a/src/typestats/index.py
+++ b/src/typestats/index.py
@@ -327,9 +327,13 @@ class _SymbolResolver:
         exports: _SymbolMap = {}
         for name in sorted(export_names):
             sym = candidates.get(name) or wildcard_symbols.get(name)
-            if sym is not None:
+
+            # Prefer import resolution over UNKNOWN local candidates
+            if sym is not None and sym.type_ is not analyze.UNKNOWN:
                 exports[name] = sym
-            elif target := import_map.get(name):
+                continue
+
+            if target := import_map.get(name):
                 resolved = self._resolve_import(
                     name,
                     target,
@@ -337,6 +341,10 @@ class _SymbolResolver:
                 )
                 if resolved is not None:
                     exports[name] = resolved
+                    continue
+
+            if sym is not None:
+                exports[name] = sym
         return exports
 
     def resolve_all(self) -> None:


### PR DESCRIPTION
the optype example in `index.py` now works as intended:

```bash
$ uv run src/typestats/index.py
2026-02-10 12:31:12 :: httpx :: INFO :: HTTP Request: GET https://files.pythonhosted.org/simple/optype/ "HTTP/2 200 OK"
2026-02-10 12:31:12 :: httpx :: INFO :: HTTP Request: GET https://files.pythonhosted.org/packages/d7/93/6b9e43138ce36fbad134bd1a50460a7bbda61105b5a964e4cf773fe4d845/optype-0.15.0.tar.gz "HTTP/2 200 OK"
2026-02-10 12:31:12 :: typestats._pypi :: INFO :: Extracted optype-0.15.0.tar.gz into /tmp/tmpzu96hwoc/optype-0.15.0
2026-02-10 12:31:12 :: typestats._ruff :: INFO :: Running subprocess: ruff analyze graph --quiet --type-checking-imports /tmp/tmpzu96hwoc/optype-0.15.0
optype/__init__.py -> 364 known, 0 unknown ()
optype/__init__.pyi -> 364 known, 0 unknown ()
optype/copy.py -> 6 known, 0 unknown ()
optype/dataclasses.py -> 1 known, 0 unknown ()
optype/dlpack.py -> 3 known, 0 unknown ()
optype/inspect.py -> 8 known, 0 unknown ()
optype/io.py -> 46 known, 0 unknown ()
optype/json.py -> 5 known, 0 unknown ()
optype/numpy/__init__.py -> 337 known, 0 unknown ()
optype/numpy/compat.py -> 25 known, 0 unknown ()
optype/numpy/ctypeslib.py -> 12 known, 0 unknown ()
optype/numpy/random.py -> 3 known, 0 unknown ()
optype/pickle.py -> 6 known, 0 unknown ()
optype/string.py -> 20 known, 0 unknown ()
optype/types/__init__.py -> 8 known, 0 unknown ()
optype/typing.py -> 18 known, 0 unknown ()
```