### PR TITLE
prioritize .pyi over .py in symbol collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ Cross-module (via import graph):
 - **Wildcard re-export expansion**: `from _internal import *` resolved to concrete symbols
 - **External vs unknown**: imported symbols from external packages marked `EXTERNAL`, not `UNKNOWN`,
   and excluded from coverage denominator
-- **Stub file priority**: Import resolution prioritizes `.pyi` files over `.py`
+- **Stub file priority**: When both `.py` and `.pyi` files exist for the same module, only the
+  `.pyi` stub is used—matching the behavior of type-checkers
   ([spec](https://typing.python.org/en/latest/spec/distributing.html#import-resolution-ordering))
 - **`py.typed` detection**: `YES`, `NO`, `PARTIAL`, or `STUBS` (for `-stubs` packages)
   ([spec](https://typing.python.org/en/latest/spec/distributing.html#packaging-type-information))

--- a/src/typestats/index.py
+++ b/src/typestats/index.py
@@ -460,6 +460,16 @@ async def collect_public_symbols(
 ) -> Mapping[anyio.Path, Sequence[analyze.Symbol]]:
     """Collect public, fully qualified symbols from a package by source path."""
     sources = list(await list_sources(project_dir))
+
+    # When both .py and .pyi exist for the same module, type-checkers only
+    # look at the .pyi stub.  Drop the .py counterparts to match that behaviour.
+    pyi_sources = frozenset(str(s) for s in sources if str(s).endswith(".pyi"))
+    sources = [
+        s
+        for s in sources
+        if not (str(s).endswith(".py") and str(s) + "i" in pyi_sources)
+    ]
+
     module_paths = sources_to_module_paths(sources)
 
     module_symbols = await _collect_module_symbols(module_paths)


### PR DESCRIPTION
this helps for performance and better matches type-checker behaviour