### PR TITLE
fix name clash issue in import resolution

### DIFF
--- a/tests/fixtures/private_reexport/mylib/_core/__init__.py
+++ b/tests/fixtures/private_reexport/mylib/_core/__init__.py
@@ -1,7 +1,9 @@
-from mylib._core import _can, _do
+from mylib._core import _can, _do, _ops
 from mylib._core._can import *
 from mylib._core._do import *
+from mylib._core._ops import *
 
 __all__: list[str] = []
 __all__ += _can.__all__
 __all__ += _do.__all__
+__all__ += _ops.__all__

--- a/tests/fixtures/private_reexport/mylib/_core/_ops/__init__.py
+++ b/tests/fixtures/private_reexport/mylib/_core/_ops/__init__.py
@@ -1,0 +1,3 @@
+from mylib._core._ops.do_mul import do_mul
+
+__all__ = ["do_mul"]

--- a/tests/fixtures/private_reexport/mylib/_core/_ops/do_mul.py
+++ b/tests/fixtures/private_reexport/mylib/_core/_ops/do_mul.py
@@ -1,0 +1,2 @@
+def do_mul(a: int, b: int) -> int:
+    return a * b


### PR DESCRIPTION
Things went wrong when e.g. importing some function `spam` from a module also named `spam`. This led to some scipy-stubs functions to be iuncorrectly marked as unannotated.