### PR TITLE
Track module-level `__getattr__` return type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ test = [
   "private-reexport",
   "private-reexport-pyi",
   "stub-typed-private",
+  "module-getattr",
 ]
 dev = [
   { include-group = "test" },
@@ -53,6 +54,7 @@ public-project = { workspace = true }
 private-reexport = { workspace = true }
 private-reexport-pyi = { workspace = true }
 stub-typed-private = { workspace = true }
+module-getattr = { workspace = true }
 
 [tool.uv.workspace]
 members = [
@@ -60,6 +62,7 @@ members = [
   "tests/fixtures/private_reexport",
   "tests/fixtures/private_reexport_pyi",
   "tests/fixtures/stub_typed_private",
+  "tests/fixtures/module_getattr",
 ]
 
 # pytest

--- a/src/typestats/index.py
+++ b/src/typestats/index.py
@@ -483,8 +483,10 @@ class _SymbolResolver:
             elif symbols.exports_explicit is not None and name not in import_map:
                 # Name listed in __all__ but not resolvable locally or via
                 # imports (e.g. provided by a module-level __getattr__).
-                # Treat as UNKNOWN so it matches type-checker behaviour.
-                exports[name] = analyze.Symbol(name, analyze.UNKNOWN)
+                # Use the __getattr__ return type when available, otherwise
+                # fall back to UNKNOWN.
+                fallback = symbols.getattr_return or analyze.UNKNOWN
+                exports[name] = analyze.Symbol(name, fallback)
         return exports
 
     def resolve_all(self) -> None:

--- a/tests/fixtures/module_getattr/getattr_pkg/__init__.py
+++ b/tests/fixtures/module_getattr/getattr_pkg/__init__.py
@@ -1,0 +1,7 @@
+from getattr_pkg.mod import dynamic_a as dynamic_a
+
+__all__ = ["dynamic_a", "dynamic_b"]
+
+
+def __getattr__(name: str) -> int:
+    ...

--- a/tests/fixtures/module_getattr/getattr_pkg/mod.py
+++ b/tests/fixtures/module_getattr/getattr_pkg/mod.py
@@ -1,0 +1,5 @@
+def __getattr__(name: str) -> int:
+    ...
+
+
+dynamic_a: int = 42

--- a/tests/fixtures/module_getattr/pyproject.toml
+++ b/tests/fixtures/module_getattr/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["uv_build<1.0"]
+build-backend = "uv_build"
+
+[tool.uv.build-backend]
+module-root = ""
+module-name = "getattr_pkg"
+
+[project]
+name = "module-getattr"
+version = "0.1.0"
+requires-python = ">=3.14"

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -264,3 +264,19 @@ def test_collect_public_symbols_same_name_module_not_unknown() -> None:
 
     assert "mylib.do_mul" in types
     assert types["mylib.do_mul"] is not analyze.UNKNOWN
+
+
+def test_collect_public_symbols_module_getattr_return_type() -> None:
+    """Names in __all__ unresolvable locally should use __getattr__ return type."""
+    types = _public_symbol_types(_FIXTURES / "module_getattr")
+
+    # dynamic_a is imported explicitly, so it should be resolved normally
+    assert "getattr_pkg.dynamic_a" in types
+    assert types["getattr_pkg.dynamic_a"] is not analyze.UNKNOWN
+
+    # dynamic_b is listed in __all__ but not defined anywhere resolvable;
+    # the module has __getattr__ -> int, so it should get that return type
+    # instead of UNKNOWN
+    assert "getattr_pkg.dynamic_b" in types
+    assert types["getattr_pkg.dynamic_b"] is not analyze.UNKNOWN
+    assert str(types["getattr_pkg.dynamic_b"]) == "int"

--- a/uv.lock
+++ b/uv.lock
@@ -4,6 +4,7 @@ requires-python = ">=3.14"
 
 [manifest]
 members = [
+    "module-getattr",
     "private-reexport",
     "private-reexport-pyi",
     "public-project",
@@ -179,6 +180,11 @@ sdist = { url = "https://files.pythonhosted.org/packages/d0/d6/e194355f8df0caee4
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/a6/61defba8bd47df1ff3935a83b4e2543f446e4450d2686b3f0429e92065a7/mainpy-1.5.0-py3-none-any.whl", hash = "sha256:6575b02777a7e8e7183197bf45192a2b4dcdd01bd2c2811ac8f800c455bbc3ed", size = 5948, upload-time = "2025-10-07T20:43:02.544Z" },
 ]
+
+[[package]]
+name = "module-getattr"
+version = "0.1.0"
+source = { editable = "tests/fixtures/module_getattr" }
 
 [[package]]
 name = "multidict"
@@ -411,6 +417,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "dprint-py" },
+    { name = "module-getattr" },
     { name = "private-reexport" },
     { name = "private-reexport-pyi" },
     { name = "public-project" },
@@ -420,6 +427,7 @@ dev = [
     { name = "stub-typed-private" },
 ]
 test = [
+    { name = "module-getattr" },
     { name = "private-reexport" },
     { name = "private-reexport-pyi" },
     { name = "public-project" },
@@ -441,6 +449,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "dprint-py", specifier = ">=0.51.1.0" },
+    { name = "module-getattr", editable = "tests/fixtures/module_getattr" },
     { name = "private-reexport", editable = "tests/fixtures/private_reexport" },
     { name = "private-reexport-pyi", editable = "tests/fixtures/private_reexport_pyi" },
     { name = "public-project", editable = "tests/fixtures/public_project" },
@@ -450,6 +459,7 @@ dev = [
     { name = "stub-typed-private", editable = "tests/fixtures/stub_typed_private" },
 ]
 test = [
+    { name = "module-getattr", editable = "tests/fixtures/module_getattr" },
     { name = "private-reexport", editable = "tests/fixtures/private_reexport" },
     { name = "private-reexport-pyi", editable = "tests/fixtures/private_reexport_pyi" },
     { name = "public-project", editable = "tests/fixtures/public_project" },


### PR DESCRIPTION
## Summary
- Add `getattr_return: TypeForm | None` field to `ModuleSymbols` to track module-level `__getattr__` return type
- Detect module-level `__getattr__` definitions in `visit_FunctionDef()` (only at module scope, not in classes)
- In `_resolve_source()`, use `getattr_return` instead of `UNKNOWN` for unresolvable `__all__` names

## Test plan
- [x] Tests verify `getattr_return` is populated when `__getattr__` exists
- [x] Tests verify `getattr_return` is `None` without `__getattr__`
- [x] Tests verify class-level `__getattr__` does not set module `getattr_return`
- [x] Tests verify unresolvable `__all__` names get `__getattr__` return type in index resolution
- [x] Fixture project `tests/fixtures/module_getattr/` for integration tests
- [x] `ruff check` passes
- [x] `pyrefly check` passes
- [x] `pytest` passes

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)