### PR TITLE
Implement CLI with typer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 requires-python = ">=3.14"
 dependencies = [
-  "mainpy>=1.5,<2", # like `if __name__ == "__main__": ...` but Pythonic
+  "typer>=0.15,<1", # CLI framework
   "anyio>=4.12.1,<5", # like asyncio but with a decent API (asyncio is a mess)
   "uvloop>=0.22.1,<1; sys_platform != 'win32'",
   "httpx[http2]>=0.28.1,<1", # like requests but modern and with async support
@@ -31,7 +31,7 @@ dependencies = [
 ]
 
 [project.scripts]
-typestats = "typestats:__main__.app"
+typestats = "typestats.__main__:app"
 
 [dependency-groups]
 test = [
@@ -44,6 +44,7 @@ test = [
 dev = [
   { include-group = "test" },
   "dprint-py>=0.51.1.0",
+  "mainpy>=1.5,<2",
   "pyrefly>=0.52.0",
   "ruff>=0.15.1",
 ]

--- a/src/typestats/__init__.py
+++ b/src/typestats/__init__.py
@@ -1,7 +1,0 @@
-import logging
-
-logging.basicConfig(
-    format="%(asctime)s :: %(name)s :: %(levelname)s :: %(message)s",
-    datefmt="%Y-%m-%d %H:%M:%S",
-    level=logging.INFO,
-)

--- a/src/typestats/__main__.py
+++ b/src/typestats/__main__.py
@@ -1,6 +1,139 @@
-from mainpy import main
+"""typestats CLI -- type annotation coverage for Python packages."""
+
+from __future__ import annotations
+
+import json
+import logging
+from enum import StrEnum
+from typing import TYPE_CHECKING, Annotated
+
+import anyio
+import typer
+
+from typestats import analyze
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
 
 
-@main
-def app() -> None:
-    print("boing")  # noqa: T201
+class OutputFormat(StrEnum):
+    """Supported output formats."""
+
+    TEXT = "text"
+    JSON = "json"
+
+
+app = typer.Typer(
+    name="typestats",
+    help="Type annotation coverage statistics for Python packages on PyPI.",
+    no_args_is_help=True,
+)
+
+
+def _version_callback(value: bool) -> None:
+    if value:
+        from importlib.metadata import version  # noqa: PLC0415
+
+        typer.echo(f"typestats {version('typestats')}")
+        raise typer.Exit
+
+
+@app.callback()
+def main(
+    *,
+    verbose: Annotated[
+        bool,
+        typer.Option("--verbose", "-v", help="Enable debug logging."),
+    ] = False,
+    version: Annotated[  # noqa: ARG001
+        bool | None,
+        typer.Option(
+            "--version",
+            help="Show version and exit.",
+            callback=_version_callback,
+            is_eager=True,
+        ),
+    ] = None,
+) -> None:
+    """Type annotation coverage statistics for Python packages on PyPI."""
+    level = logging.DEBUG if verbose else logging.INFO
+    if not logging.root.handlers:
+        logging.basicConfig(level=level, format="%(levelname)s: %(message)s")
+    else:
+        logging.root.setLevel(level)
+
+
+@app.command()
+def check(
+    package: Annotated[str, typer.Argument(help="PyPI package name to analyze.")],
+    *,
+    output: Annotated[
+        OutputFormat,
+        typer.Option("--output", "-o", help="Output format."),
+    ] = OutputFormat.TEXT,
+    temp_dir: Annotated[
+        str | None,
+        typer.Option("--temp-dir", help="Directory for downloaded packages."),
+    ] = None,
+) -> None:
+    """Analyze type annotation coverage for a PyPI package."""  # noqa: DOC501
+    import httpx  # noqa: PLC0415
+
+    try:
+        anyio.run(_check_async, package, output, temp_dir)
+    except httpx.HTTPError as exc:
+        typer.echo(f"HTTP error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+    except ValueError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+
+async def _check_async(
+    package: str,
+    output: OutputFormat,
+    temp_dir: str | None,
+) -> None:
+    import tempfile  # noqa: PLC0415
+
+    import httpx  # noqa: PLC0415
+
+    from typestats._pypi import download_sdist_latest  # noqa: PLC0415
+    from typestats.index import collect_public_symbols  # noqa: PLC0415
+
+    work_dir = temp_dir or tempfile.mkdtemp(prefix="typestats-")
+
+    async with httpx.AsyncClient(http2=True) as client:
+        path, _file_detail = await download_sdist_latest(client, package, work_dir)
+
+    symbols = await collect_public_symbols(path)
+    _report(symbols, output, package)
+
+
+def _report(
+    symbols: Mapping[anyio.Path, Sequence[analyze.Symbol]],
+    output: OutputFormat,
+    package: str,
+) -> None:
+    total = sum(len(syms) for syms in symbols.values())
+    annotated = sum(
+        sum(1 for s in syms if analyze.is_annotated(s.type_))
+        for syms in symbols.values()
+    )
+
+    if output == OutputFormat.JSON:
+        typer.echo(
+            json.dumps(
+                {
+                    "package": package,
+                    "modules": len(symbols),
+                    "symbols_total": total,
+                    "symbols_annotated": annotated,
+                },
+                indent=2,
+            ),
+        )
+    else:
+        typer.echo(f"Package: {package}")
+        typer.echo(f"Modules: {len(symbols)}")
+        typer.echo(f"Symbols: {annotated}/{total} annotated")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,39 @@
+"""Tests for the typestats CLI."""
+
+from unittest.mock import AsyncMock, patch
+
+from typer.testing import CliRunner
+
+from typestats.__main__ import app
+
+runner = CliRunner()
+
+
+class TestCLI:
+    def test_help(self) -> None:
+        result = runner.invoke(app, ["--help"])
+        assert result.exit_code == 0
+        assert "typestats" in result.output.lower() or "type" in result.output.lower()
+
+    def test_version(self) -> None:
+        result = runner.invoke(app, ["--version"])
+        assert result.exit_code == 0
+        assert "typestats" in result.output
+
+    def test_no_args_shows_help(self) -> None:
+        result = runner.invoke(app)
+        assert result.exit_code == 2  # no_args_is_help exits with code 2
+        assert "Usage" in result.output or "usage" in result.output
+
+    def test_check_help(self) -> None:
+        result = runner.invoke(app, ["check", "--help"])
+        assert result.exit_code == 0
+        assert "package" in result.output.lower()
+
+    def test_check_invokes_async(self) -> None:
+        with patch("typestats.__main__._check_async", new_callable=AsyncMock) as mock:
+            result = runner.invoke(app, ["check", "example-pkg"])
+            assert result.exit_code == 0
+            mock.assert_called_once()
+            args = mock.call_args.args
+            assert args[0] == "example-pkg"

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,15 @@ members = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -30,6 +39,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
 ]
 
 [[package]]
@@ -178,6 +199,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d0/d6/e194355f8df0caee4124226308cb5bbfe4f502378cc3ec531e5d4c508144/mainpy-1.5.0.tar.gz", hash = "sha256:6083d34ad0f3e0fa07e144f03c9dae32b0fa1554b0213053dd19994c0a169fd8", size = 6761, upload-time = "2025-10-07T20:43:04.255Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/a6/61defba8bd47df1ff3935a83b4e2543f446e4450d2686b3f0429e92065a7/mainpy-1.5.0-py3-none-any.whl", hash = "sha256:6575b02777a7e8e7183197bf45192a2b4dcdd01bd2c2811ac8f800c455bbc3ed", size = 5948, upload-time = "2025-10-07T20:43:02.544Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -365,6 +407,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "14.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/99/a4cab2acbb884f80e558b0771e97e21e939c5dfb460f488d19df485e8298/rich-14.3.2.tar.gz", hash = "sha256:e712f11c1a562a11843306f5ed999475f09ac31ffb64281f73ab29ffdda8b3b8", size = 230143, upload-time = "2026-02-01T16:20:47.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/45/615f5babd880b4bd7d405cc0dc348234c5ffb6ed1ea33e152ede08b2072d/rich-14.3.2-py3-none-any.whl", hash = "sha256:08e67c3e90884651da3239ea668222d19bea7b589149d8014a21c633420dbb69", size = 309963, upload-time = "2026-02-01T16:20:46.078Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.1"
 source = { registry = "https://pypi.org/simple" }
@@ -390,9 +445,33 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "stub-typed-private"
 version = "0.1.0"
 source = { editable = "tests/fixtures/stub_typed_private" }
+
+[[package]]
+name = "typer"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/07/b822e1b307d40e263e8253d2384cf98c51aa2368cc7ba9a07e523a1d964b/typer-0.23.1.tar.gz", hash = "sha256:2070374e4d31c83e7b61362fd859aa683576432fd5b026b060ad6b4cd3b86134", size = 120047, upload-time = "2026-02-13T10:04:30.984Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/91/9b286ab899c008c2cb05e8be99814807e7fbbd33f0c0c960470826e5ac82/typer-0.23.1-py3-none-any.whl", hash = "sha256:3291ad0d3c701cbf522012faccfbb29352ff16ad262db2139e6b01f15781f14e", size = 56813, upload-time = "2026-02-13T10:04:32.008Z" },
+]
 
 [[package]]
 name = "typestats"
@@ -402,8 +481,8 @@ dependencies = [
     { name = "anyio" },
     { name = "httpx", extra = ["http2"] },
     { name = "libcst" },
-    { name = "mainpy" },
     { name = "packaging" },
+    { name = "typer" },
     { name = "uvloop", marker = "sys_platform != 'win32'" },
     { name = "yarl" },
 ]
@@ -411,6 +490,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "dprint-py" },
+    { name = "mainpy" },
     { name = "private-reexport" },
     { name = "private-reexport-pyi" },
     { name = "public-project" },
@@ -432,8 +512,8 @@ requires-dist = [
     { name = "anyio", specifier = ">=4.12.1,<5" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.28.1,<1" },
     { name = "libcst", specifier = ">=1.8.6,<2" },
-    { name = "mainpy", specifier = ">=1.5,<2" },
     { name = "packaging", specifier = ">=26.0" },
+    { name = "typer", specifier = ">=0.15,<1" },
     { name = "uvloop", marker = "sys_platform != 'win32'", specifier = ">=0.22.1,<1" },
     { name = "yarl", specifier = ">=1.22.0,<2" },
 ]
@@ -441,6 +521,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "dprint-py", specifier = ">=0.51.1.0" },
+    { name = "mainpy", specifier = ">=1.5,<2" },
     { name = "private-reexport", editable = "tests/fixtures/private_reexport" },
     { name = "private-reexport-pyi", editable = "tests/fixtures/private_reexport_pyi" },
     { name = "public-project", editable = "tests/fixtures/public_project" },


### PR DESCRIPTION
## Summary
- Add `typer>=0.15,<1` dependency, move `mainpy` to dev dependencies
- Rewrite `__main__.py` with typer: `--verbose`, `--version`, and `check` command
- `check` command downloads a PyPI package, analyzes type annotation coverage, and reports results (text or JSON)
- Move logging configuration from `__init__.py` to CLI callback

## Test plan
- [x] Tests for `--help`, `--version`, no-args behavior, `check --help`
- [x] `ruff check` passes
- [x] `pyrefly check` passes
- [x] `pytest` passes

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)