### PR TITLE
stringified annotations support

### DIFF
--- a/tests/fixtures/project/anypkg/mod.py
+++ b/tests/fixtures/project/anypkg/mod.py
@@ -3,11 +3,13 @@ from typing import Any
 from anypkg._defs import Chained, NotAny, Remote, Unknown
 
 any_var: Any = None
+string_any_var: "Any" = None
 unknown_var: Unknown = None
 chained_var: Chained = None
 remote_var: Remote = None
 normal_var: int = 1
 not_any_alias_var: NotAny = 1
+string_int_var: "int" = 1
 
 
 def annotated_func(a: Unknown, b: int) -> str:

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -350,6 +350,22 @@ def test_collect_public_symbols_direct_any_is_any() -> None:
     assert types["anypkg.mod.any_var"] is analyze.ANY
 
 
+def test_collect_public_symbols_string_any_is_any() -> None:
+    """Stringified `"Any"` annotation should be detected as ANY."""
+    types = _public_symbol_types(_PROJECT)
+
+    assert "anypkg.mod.string_any_var" in types
+    assert types["anypkg.mod.string_any_var"] is analyze.ANY
+
+
+def test_collect_public_symbols_string_annotation_not_any() -> None:
+    """Stringified non-Any annotation should NOT be detected as ANY."""
+    types = _public_symbol_types(_PROJECT)
+
+    assert "anypkg.mod.string_int_var" in types
+    assert types["anypkg.mod.string_int_var"] is not analyze.ANY
+
+
 def test_collect_public_symbols_alias_to_any_is_any() -> None:
     """Symbols annotated with a type alias that resolves to Any should be ANY."""
     types = _public_symbol_types(_PROJECT)


### PR DESCRIPTION
it's probably the worst hack in the history of type-system design, but unfortunately it's used all over the place (thanks ruff).