### PR TITLE
PyPI package listing

### DIFF
--- a/src/typestats/_pypi.py
+++ b/src/typestats/_pypi.py
@@ -134,7 +134,7 @@ async def fetch_project_detail(
 
 async def fetch_top_packages(client: httpx.AsyncClient, n: int, /) -> list[TopPackage]:
     """Fetch the top *n* most-downloaded PyPI packages (over the last 30 days)."""
-    assert n >= 0, "n must be a non-negative integer"
+    assert n > 0, "n must be a positive integer"
     # the CSV is less than half the size of the minified JSON
     data = await _get_csv(client, TOP_30D)
     return [
@@ -243,7 +243,7 @@ async def example() -> None:
     async with retry_client() as client:
         if sys.argv[1:]:
             project = sys.argv[1]
-            path = await download_sdist_latest(client, project, "./projects")
+            path, _ = await download_sdist_latest(client, project, "./projects")
             print(f"Downloaded {project} to {path}")  # noqa: T201
         else:
             top_packages = await fetch_top_packages(client, 42)


### PR DESCRIPTION
This adds a function that lists the top N (at most 15,000) most downloaded PyPI packages in the last 30 days. 
For example, running `uv run scr/typestats/_pypi.py` now outputs the following:

```
2026-02-17 21:32:57 :: httpx :: INFO :: HTTP Request: GET https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.csv "HTTP/2 200 OK"
Rank Package              Downloads (30 days)
   1 boto3                 1,611,866,263
   2 urllib3               1,175,106,368
   3 botocore              1,123,184,624
   4 packaging             1,039,572,201
   5 certifi               1,035,681,084
   6 typing-extensions     1,030,628,027
   7 requests              1,012,392,229
   8 setuptools              984,290,835
   9 idna                    965,077,176
  10 charset-normalizer      942,165,819
  11 aiobotocore             910,441,874
  12 python-dateutil         781,908,395
  13 grpcio-status           738,773,290
  14 six                     737,574,118
  15 s3transfer              672,553,216
  16 numpy                   669,259,413
  17 cryptography            637,161,281
  18 pyyaml                  618,206,804
  19 cffi                    601,244,913
  20 pydantic                566,059,491
  21 fsspec                  556,219,247
  22 s3fs                    556,025,300
  23 pycparser               545,015,284
  24 pluggy                  523,408,097
  25 protobuf                501,261,208
  26 click                   498,850,774
  27 pygments                497,022,714
  28 pandas                  487,678,975
  29 attrs                   467,768,819
  30 pydantic-core           461,198,822
  31 pytest                  434,671,727
  32 markupsafe              434,554,368
  33 jmespath                432,087,584
  34 h11                     429,195,942
  35 pip                     426,779,593
  36 platformdirs            419,979,004
  37 anyio                   419,161,803
  38 iniconfig               414,971,486
  39 rsa                     397,071,815
  40 awscli                  395,363,897
  41 pytz                    394,422,733
  42 filelock                392,662,699
```
