### PR TITLE
Handle version-guarded imports

### DIFF
--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -4,7 +4,6 @@ import textwrap
 import libcst as cst
 import pytest
 
-from typestats import analyze
 from typestats.analyze import (
     ANY,
     EXTERNAL,
@@ -1337,30 +1336,26 @@ class TestVersionGuards:
 
     def test_dead_version_branch_is_not_traversed(
         self,
-        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         src = textwrap.dedent("""
         import sys
 
         if sys.version_info < (3, 10):
-            dead_inner: int = 1
+            if sys.version_info[:2] >= (3, 11):
+                dead_inner: int = 1
         else:
             live_inner: str = "hello"
         """)
-        annassign_visits = 0
-        original = analyze._SymbolVisitor.visit_AnnAssign  # noqa: SLF001
-
-        def visit_annassign(
-            self: analyze._SymbolVisitor,
-            node: cst.AnnAssign,
-        ) -> None:
-            nonlocal annassign_visits
-            annassign_visits += 1
-            original(self, node)
-
-        monkeypatch.setattr(analyze._SymbolVisitor, "visit_AnnAssign", visit_annassign)  # noqa: SLF001
-        collect_symbols(src)
-        assert annassign_visits == 1
+        with caplog.at_level(logging.WARNING, logger="typestats.analyze"):
+            module = collect_symbols(src)
+        messages = [record.getMessage() for record in caplog.records]
+        symbols = {s.name for s in module.symbols}
+        assert not any(
+            "subscripted sys.version_info is not supported" in msg for msg in messages
+        )
+        assert "dead_inner" not in symbols
+        assert "live_inner" in symbols
 
     def test_skipped_function_branch_does_not_corrupt_depth(self) -> None:
         src = textwrap.dedent("""


### PR DESCRIPTION
## Summary

Resolves #25 — handle `sys.version_info` guards in `collect_symbols()`.

- Adds `_VersionGuardTransformer` (CST transformer) that evaluates `sys.version_info >= (3, X)` and `< (3, X)` comparisons against the running Python version
- Matching branches are flattened into module scope; non-matching branches are removed
- The transformer gathers its own import map during traversal (no extra pass needed)
- Supports: `import sys` / `from sys import version_info` / aliased imports
- Handles `if`/`elif`/`else` chains, including nested version guards
- 12 new tests covering all guard patterns

## Architecture

```
parse → Pass 1 (CSTTransformer: resolve version guards, self-gathers imports)
      → Pass 2 (CSTVisitor: collect symbols — unchanged from main)
```

The transformer runs as a single extra CST traversal before the existing single-pass visitor. This is the minimum overhead possible — the transformer must modify the tree before symbols can be collected.

## Performance

Benchmarked with 300 iterations each, 20 warmup iterations, using `time.perf_counter()`.

| Scenario | Main (1 pass) | Branch, no guards (2 pass) | Branch, with guards (2 pass) |
|----------|--------------|---------------------------|------------------------------|
| Small file (~30 LOC) | 2.81 ms | 4.24 ms (1.51x) | 5.12 ms (1.82x) |
| Large file (~150 LOC, 50 funcs) | 27.54 ms | 43.09 ms (1.56x) | 45.06 ms (1.64x) |

The overhead is the cost of the additional CST traversal. For files without version guards, the transformer traverses but makes no modifications. For files with guards, there's additional work to evaluate comparisons and transform the tree.

## Test plan

- [x] All 285 tests pass (`uv run pytest --ignore=tests/fixtures -x`)
- [x] `uv run ruff check` — no lint errors
- [x] `uv run ruff format --check` — formatted
- [x] Correctness: `Self` resolves to `typing.Self` (not `typing_extensions.Self`)
- [x] Version guards with `>=`, `<` operators correctly evaluated
- [x] `elif` chains and `else` branches handled
- [x] Aliased sys imports supported