### PR TITLE
remove json indentation from reports

### DIFF
--- a/src/typestats/collect.py
+++ b/src/typestats/collect.py
@@ -94,7 +94,7 @@ async def collect_project(
                 exclude=project.exclude,
             )
 
-        json_bytes = report.model_dump_json(indent=2).encode()
+        json_bytes = report.model_dump_json().encode()
         await out.parent.mkdir(parents=True, exist_ok=True)
         await out.write_bytes(json_bytes)
         _logger.info("  %s %s - wrote %s", project.name, version, out)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -494,7 +494,7 @@ class TestPackageReportJson:
     def test_round_trip(self) -> None:
         """model_dump_json → model_validate_json should reproduce the report."""
         report = self._pkg(Symbol("a", _INT), Symbol("b", ANY), Symbol("c", UNKNOWN))
-        json_str = report.model_dump_json(indent=2)
+        json_str = report.model_dump_json()
         restored = PackageReport.model_validate_json(json_str)
         assert restored == report
 


### PR DESCRIPTION
this'll approximately half the size on disk