### PR TITLE
recover from libcst recursion error

### DIFF
--- a/src/typestats/analyze.py
+++ b/src/typestats/analyze.py
@@ -1177,7 +1177,14 @@ def collect_symbols(
 
     # Single pass: collects symbols AND evaluates version guards.
     visitor = _SymbolVisitor(package_name=package_name or "")
-    module.visit(visitor)
+    try:
+        module.visit(visitor)
+    except RecursionError:
+        _logger.warning(
+            "skipping module %s: CST too deeply nested (recursion limit hit)",
+            package_name or "<unknown>",
+        )
+        return _EMPTY_SYMBOLS
 
     imports = visitor.imports
 

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -38,6 +38,18 @@ class TestEmptySource:
         assert result.type_check_only == frozenset()
 
 
+class TestRecursionError:
+    def test_deeply_nested_source_returns_empty(self) -> None:
+        """Deeply nested expressions should not crash; return empty symbols."""
+        from unittest.mock import patch  # noqa: PLC0415
+
+        source = "x = 1"
+        with patch("libcst.Module.visit", side_effect=RecursionError):
+            result = collect_symbols(source)
+        assert result.symbols == ()
+        assert result.type_aliases == ()
+
+
 class TestImports:
     def test_basic(self) -> None:
         src = textwrap.dedent("""


### PR DESCRIPTION
I'm not sure why, but in `av==14.4.0` this happens.