### PR TITLE
use indent=2 to pretty-print json output

### DIFF
--- a/src/typestats/collect.py
+++ b/src/typestats/collect.py
@@ -133,7 +133,7 @@ async def collect_project(
                 exclude=project.exclude,
             )
 
-        json_bytes = report.model_dump_json().encode()
+        json_bytes = report.model_dump_json(indent=2).encode()
         await out.parent.mkdir(parents=True, exist_ok=True)
         await out.write_bytes(json_bytes)
         _logger.info("  %s %s - wrote %s", project.name, version, out)


### PR DESCRIPTION
Currently the json outputs appear on a single line so they're hard to inspect visually

By adding `indent=2`, they because much easier to analyse

Alternatively, I could just make my own postprocessing script when analysing these files, but I think this is useful enough to be the default