### PR TITLE
ignore COM812 ruff rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ line-ending = "lf"
 select = ["ALL"]
 ignore = [
   "ANN401", # flake8-annotations - any-type
+  "COM812", # missing-trailing-comma - conflicts with formatter
   "S101", # flake8-bandit - assert
   "FBT", # flake8-boolean-trap
   "CPY", # flake8-copyright


### PR DESCRIPTION
running ruff format gives
```
warning: The following rule may cause conflicts when used with the formatter: `COM812`. To avoid unexpected behavior, we recommend disabling this rule, either by removing it from the `lint.select` or `lint.extend-select` configuration, or adding it to the `lint.ignore` configuration.
```