### PR TITLE
preserve kind of missing stub symbols

### DIFF
--- a/src/typestats/analyze.py
+++ b/src/typestats/analyze.py
@@ -144,6 +144,9 @@ class _TypeMarker(StrEnum):
     def __str__(self) -> str:
         return self.value
 
+    def to_unknown(self) -> _TypeMarker:  # noqa: PLR6301
+        return _TypeMarker.UNKNOWN
+
 
 type _UnknownType = Literal[_TypeMarker.UNKNOWN]
 type _KnownType = Literal[_TypeMarker.KNOWN]
@@ -163,6 +166,7 @@ _Sequence: _TypeAlias = cst.List | cst.Tuple  # noqa: UP040
 _Container: _TypeAlias = _Sequence | cst.Set  # noqa: UP040
 
 
+# TODO(@jorenham): turn this into a polymorphic method on TypeForm variants
 def is_annotated(type_: TypeForm, /) -> bool:
     """Check if a type form represents a meaningfully annotated symbol.
 
@@ -219,6 +223,9 @@ class Expr:
     ) -> Self:
         return cls(_unwrap_annotated(_parse_string_annotation(expr), name_resolver))
 
+    def to_unknown(self) -> _UnknownType:  # noqa: PLR6301
+        return UNKNOWN
+
 
 @dataclass(frozen=True, slots=True)
 class Param:
@@ -257,6 +264,11 @@ class Overload:
     params: tuple[Param, ...]
     returns: TypeForm
 
+    @override
+    def __str__(self) -> str:
+        params = ", ".join(str(param) for param in self.params)
+        return f"({params}) -> {self.returns}"
+
     @property
     def is_annotated(self) -> bool:
         return is_annotated(self.returns) or any(p.is_annotated for p in self.params)
@@ -274,10 +286,11 @@ class Overload:
             annotatable=len(states),
         )
 
-    @override
-    def __str__(self) -> str:
-        params = ", ".join(str(param) for param in self.params)
-        return f"({params}) -> {self.returns}"
+    def to_unknown(self) -> Self:
+        return type(self)(
+            tuple(Param(p.name, p.kind, UNKNOWN) for p in self.params),
+            UNKNOWN,
+        )
 
 
 class _SlotRank(IntEnum):
@@ -366,6 +379,13 @@ class Function:
             annotatable=len(all_states),
         )
 
+    def to_unknown(self) -> Self:
+        first, *rest = self.overloads
+        return type(self)(
+            self.name,
+            (first.to_unknown(), *(o.to_unknown() for o in rest)),
+        )
+
 
 @dataclass(frozen=True, slots=True)
 class Property:
@@ -373,6 +393,17 @@ class Property:
     fget: Overload | None = None
     fset: Overload | None = None
     fdel: Overload | None = None
+
+    @override
+    def __str__(self) -> str:
+        parts: list[str] = []
+        if self.fget is not None:
+            parts.append(f"fget={self.fget}")
+        if self.fset is not None:
+            parts.append(f"fset={self.fset}")
+        if self.fdel is not None:
+            parts.append(f"fdel={self.fdel}")
+        return f"property({', '.join(parts)})"
 
     @property
     def is_annotated(self) -> bool:
@@ -407,22 +438,23 @@ class Property:
 
         return _AnnotationCounts(annotated, any_, total)
 
-    @override
-    def __str__(self) -> str:
-        parts: list[str] = []
-        if self.fget is not None:
-            parts.append(f"fget={self.fget}")
-        if self.fset is not None:
-            parts.append(f"fset={self.fset}")
-        if self.fdel is not None:
-            parts.append(f"fdel={self.fdel}")
-        return f"property({', '.join(parts)})"
+    def to_unknown(self) -> Self:
+        return type(self)(
+            self.name,
+            self.fget.to_unknown() if self.fget else None,
+            self.fset.to_unknown() if self.fset else None,
+            self.fdel.to_unknown() if self.fdel else None,
+        )
 
 
 @dataclass(frozen=True, slots=True)
 class Class:
     name: str
     members: tuple[TypeForm, ...] = ()
+
+    @override
+    def __str__(self) -> str:
+        return f"type[{self.name}]"
 
     @property
     def is_annotated(self) -> bool:
@@ -438,9 +470,11 @@ class Class:
             sum(c.annotatable for c in counts),
         )
 
-    @override
-    def __str__(self) -> str:
-        return f"type[{self.name}]"
+    def to_unknown(self) -> Self:
+        return type(self)(
+            self.name,
+            tuple(m.to_unknown() for m in self.members),
+        )
 
 
 def annotation_counts(type_: TypeForm, /) -> _AnnotationCounts:

--- a/src/typestats/index.py
+++ b/src/typestats/index.py
@@ -700,11 +700,12 @@ def merge_stubs_overlay(
     with `trace_origins=False` so that symbol FQNs are public import names
     and paths point to the public module file (not origin files).
 
-    Stubs types take priority.  Original symbols whose modules are covered by
-    stubs but that are absent from those stubs are marked `UNKNOWN` (matching
-    type-checker behaviour: stubs shadow the `.py`) and are consolidated
-    under the stubs path.  Original symbols whose modules are *not* covered by
-    stubs retain their original types (the type-checker falls back to the `.py`).
+    Stubs types take priority. Original symbols whose modules are covered by stubs but
+    that are absent from those stubs have their annotations stripped (matching
+    type-checker behaviour: stubs shadow the `.py`) while preserving the structural
+    kind (function, property, class). These symbols are consolidated under the stubs
+    path. Original symbols whose modules are *not* covered by stubs retain their
+    original types (the type-checker falls back to the `.py`).
     """
 
     # Flatten stubs to {fqn: (path, type)} and build module -> stubs-path map
@@ -726,11 +727,11 @@ def merge_stubs_overlay(
             if sym.name not in merged:
                 mod = sym.name.rsplit(".", 1)[0]
                 if mod in stubs_modules:
-                    # Module covered by stubs but symbol missing -> UNKNOWN,
-                    # consolidated under the stubs path for this module
-                    merged[sym.name] = (stubs_mod_path[mod], analyze.UNKNOWN)
+                    # module covered by stubs but symbol missing:
+                    # strip annotations but preserve its kind (func, prop, class, etc)
+                    merged[sym.name] = stubs_mod_path[mod], sym.type_.to_unknown()
                 else:
-                    merged[sym.name] = (path, sym.type_)
+                    merged[sym.name] = path, sym.type_
 
     # Group by path
     result: defaultdict[anyio.Path, list[analyze.Symbol]] = defaultdict(list)

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -1288,6 +1288,138 @@ class TestAnnotationCounts:
         assert annotation_counts(cls) == (0, 1, 1)
 
 
+class TestToUnknown:
+    _INT: TypeForm = Expr(cst.parse_expression("int"))
+
+    def test_markers(self) -> None:
+        assert UNKNOWN.to_unknown() is UNKNOWN
+        assert KNOWN.to_unknown() is UNKNOWN
+        assert ANY.to_unknown() is UNKNOWN
+        assert EXTERNAL.to_unknown() is UNKNOWN
+
+    def test_expr(self) -> None:
+        assert self._INT.to_unknown() is UNKNOWN
+
+    def test_overload(self) -> None:
+        overload = Overload(
+            (Param("x", ParamKind.POSITIONAL_OR_KEYWORD, self._INT),),
+            self._INT,
+        )
+        result = overload.to_unknown()
+        assert isinstance(result, Overload)
+        assert result.returns is UNKNOWN
+        assert len(result.params) == 1
+        assert result.params[0].name == "x"
+        assert result.params[0].kind is ParamKind.POSITIONAL_OR_KEYWORD
+        assert result.params[0].annotation is UNKNOWN
+
+    def test_function_single_overload(self) -> None:
+        func = Function(
+            "f",
+            (
+                Overload(
+                    (Param("x", ParamKind.POSITIONAL_OR_KEYWORD, self._INT),),
+                    self._INT,
+                ),
+            ),
+        )
+        result = func.to_unknown()
+        assert isinstance(result, Function)
+        assert result.name == "f"
+        assert not result.is_annotated
+        assert len(result.overloads) == 1
+        assert result.overloads[0].returns is UNKNOWN
+        assert result.overloads[0].params[0].annotation is UNKNOWN
+
+    def test_function_multiple_overloads(self) -> None:
+        func = Function(
+            "f",
+            (
+                Overload(
+                    (Param("x", ParamKind.POSITIONAL_OR_KEYWORD, self._INT),),
+                    self._INT,
+                ),
+                Overload(
+                    (Param("x", ParamKind.POSITIONAL_OR_KEYWORD, self._INT),),
+                    self._INT,
+                ),
+            ),
+        )
+        result = func.to_unknown()
+        assert isinstance(result, Function)
+        assert len(result.overloads) == 2
+        for overload in result.overloads:
+            assert overload.returns is UNKNOWN
+            assert overload.params[0].annotation is UNKNOWN
+
+    def test_property_fget(self) -> None:
+        prop = Property("p", fget=Overload((), self._INT))
+        result = prop.to_unknown()
+        assert isinstance(result, Property)
+        assert result.name == "p"
+        assert result.fget is not None
+        assert result.fget.returns is UNKNOWN
+        assert result.fset is None
+        assert result.fdel is None
+
+    def test_property_fget_fset(self) -> None:
+        prop = Property(
+            "p",
+            fget=Overload((), self._INT),
+            fset=Overload(
+                (Param("value", ParamKind.POSITIONAL_OR_KEYWORD, self._INT),),
+                self._INT,
+            ),
+        )
+        result = prop.to_unknown()
+        assert isinstance(result, Property)
+        assert result.fget is not None
+        assert result.fget.returns is UNKNOWN
+        assert result.fset is not None
+        assert result.fset.params[0].annotation is UNKNOWN
+        assert result.fset.returns is UNKNOWN
+
+    def test_property_none_accessors(self) -> None:
+        prop = Property("p")
+        result = prop.to_unknown()
+        assert isinstance(result, Property)
+        assert result.fget is None
+        assert result.fset is None
+        assert result.fdel is None
+
+    def test_class_no_members(self) -> None:
+        cls = Class("C")
+        result = cls.to_unknown()
+        assert isinstance(result, Class)
+        assert result.name == "C"
+        assert result.members == ()
+
+    def test_class_with_members(self) -> None:
+        cls = Class("C", members=(self._INT, ANY))
+        result = cls.to_unknown()
+        assert isinstance(result, Class)
+        assert len(result.members) == 2
+        assert all(m is UNKNOWN for m in result.members)
+
+    def test_class_nested_function_member(self) -> None:
+        func = Function(
+            "method",
+            (
+                Overload(
+                    (Param("x", ParamKind.POSITIONAL_OR_KEYWORD, self._INT),),
+                    self._INT,
+                ),
+            ),
+        )
+        cls = Class("C", members=(func,))
+        result = cls.to_unknown()
+        assert isinstance(result, Class)
+        assert len(result.members) == 1
+        member = result.members[0]
+        assert isinstance(member, Function)
+        assert not member.is_annotated
+
+
 class TestTypeCheckOnly:
     def test_function_detected(self) -> None:
         src = textwrap.dedent("""

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -668,6 +668,68 @@ class TestMergeStubsOverlay:
         stubs_names = {s.name for s in merged.get(stubs_path, [])}
         assert "pkg.orphan" in stubs_names
 
+    def test_missing_function_preserves_kind(self) -> None:
+        """Function missing from stubs keeps Function kind, unannotated."""
+        func = analyze.Function(
+            "f",
+            (
+                analyze.Overload(
+                    (
+                        analyze.Param(
+                            "x", analyze.ParamKind.POSITIONAL_OR_KEYWORD, self._INT
+                        ),
+                    ),
+                    self._INT,
+                ),
+            ),
+        )
+        orig = {
+            anyio.Path("/a/pkg/__init__.py"): [
+                analyze.Symbol("pkg.x", self._INT),
+                analyze.Symbol("pkg.f", func),
+            ],
+        }
+        stubs = {
+            anyio.Path("/b/pkg-stubs/__init__.pyi"): [
+                analyze.Symbol("pkg.x", self._INT),
+            ],
+        }
+        flat = {
+            s.name: s.type_
+            for v in merge_stubs_overlay(orig, stubs).values()
+            for s in v
+        }
+        result = flat["pkg.f"]
+        assert isinstance(result, analyze.Function)
+        assert not result.is_annotated
+        # params structure preserved, but annotations stripped
+        assert len(result.overloads[0].params) == 1
+        assert result.overloads[0].params[0].annotation is analyze.UNKNOWN
+        assert result.overloads[0].returns is analyze.UNKNOWN
+
+    def test_missing_class_preserves_kind(self) -> None:
+        """Class missing from stubs keeps Class kind, unannotated."""
+        cls = analyze.Class("C", members=(self._INT, self._INT))
+        orig = {
+            anyio.Path("/a/pkg/__init__.py"): [
+                analyze.Symbol("pkg.x", self._INT),
+                analyze.Symbol("pkg.C", cls),
+            ],
+        }
+        stubs = {
+            anyio.Path("/b/pkg-stubs/__init__.pyi"): [
+                analyze.Symbol("pkg.x", self._INT),
+            ],
+        }
+        flat = {
+            s.name: s.type_
+            for v in merge_stubs_overlay(orig, stubs).values()
+            for s in v
+        }
+        result = flat["pkg.C"]
+        assert isinstance(result, analyze.Class)
+        assert not result.is_annotated
+
 
 @functools.cache
 def _merged_stubs_types() -> dict[str, analyze.TypeForm]:
@@ -695,11 +757,13 @@ def test_merge_stubs_overlay_stubs_only_symbol() -> None:
     assert types["mypkg.dynamic_func"] is not analyze.UNKNOWN
 
 
-def test_merge_stubs_overlay_missing_from_stubs_unknown() -> None:
-    """Original symbol not in stubs (module covered) -> UNKNOWN."""
+def test_merge_stubs_overlay_missing_from_stubs_preserves_kind() -> None:
+    """Original function not in stubs (module covered) keeps Function kind."""
     types = _merged_stubs_types()
     assert "mypkg.extra_func" in types
-    assert types["mypkg.extra_func"] is analyze.UNKNOWN
+    tf = types["mypkg.extra_func"]
+    assert isinstance(tf, analyze.Function)
+    assert not tf.is_annotated
 
 
 def test_merge_stubs_overlay_uncovered_module_original() -> None:


### PR DESCRIPTION
this fixes missing stubs always being labels as "name" kind