### PR TITLE
fix package metadata discovery

### DIFF
--- a/src/typestats/_metadata.py
+++ b/src/typestats/_metadata.py
@@ -1,5 +1,6 @@
 import email.parser
 import logging
+import re
 
 import anyio
 
@@ -14,12 +15,24 @@ _logger = logging.getLogger(__name__)
 _EXCLUDED_HEADERS: frozenset[str] = frozenset({"description"})
 
 
-async def read_pkg_metadata(path: StrPath, /) -> _Metadata | None:
+def _normalize_dist_name(name: str, /) -> str:
+    return re.sub(r"[-_.]+", "_", name).lower()
+
+
+async def read_pkg_metadata(
+    path: StrPath,
+    /,
+    dist_name: str | None = None,
+) -> _Metadata | None:
     """Read package metadata from an extracted distribution at `path`.
 
     Looks for `PKG-INFO` (sdist layout) or `*.dist-info/METADATA` (wheel layout).
     Returns header values as `{header: [value, ...]}`. Multi-valued fields like
     `Classifier` naturally become multi-element lists.
+
+    When `dist_name` is given, only the `.dist-info` directory matching that
+    distribution name is considered (avoiding false matches when multiple distributions
+    share the same `site-packages` root).
 
     The `Description` header (which contains the readme body) is excluded.
 
@@ -33,11 +46,15 @@ async def read_pkg_metadata(path: StrPath, /) -> _Metadata | None:
         return await _parse_metadata_file(pkg_info)
 
     # wheel layout: {name}-{version}.dist-info/METADATA
+    needle = _normalize_dist_name(dist_name) if dist_name is not None else None
     async for child in root.iterdir():
-        if child.name.endswith(".dist-info") and await child.is_dir():
-            meta_file = child / "METADATA"
-            if await meta_file.is_file():
-                return await _parse_metadata_file(meta_file)
+        if not child.name.endswith(".dist-info") or not await child.is_dir():
+            continue
+        if needle and _normalize_dist_name(child.name.split("-", 1)[0]) != needle:
+            continue
+        meta_file = child / "METADATA"
+        if await meta_file.is_file():
+            return await _parse_metadata_file(meta_file)
 
     _logger.debug("No PKG-INFO or .dist-info/METADATA found in %s", path)
     return None

--- a/src/typestats/report.py
+++ b/src/typestats/report.py
@@ -856,6 +856,7 @@ class PackageReport(BaseModel):  # noqa: PLR0904
             exclude,
             sources=sources,
             stubs_sources=stubs_sources,
+            dist_name=project or pkg,
         )
         built = await cls._build_module_reports(
             collected.symbols,
@@ -894,6 +895,7 @@ class PackageReport(BaseModel):  # noqa: PLR0904
         *,
         sources: StrPaths = (),
         stubs_sources: StrPaths = (),
+        dist_name: str = "",
     ) -> _CollectResult:
         """Run analysis coroutines and return merged results."""
         from typestats._metadata import read_pkg_metadata
@@ -920,7 +922,7 @@ class PackageReport(BaseModel):  # noqa: PLR0904
                     sources=stubs_sources,
                 ),
             )
-        coros.append(read_pkg_metadata(stubs_path or path))
+        coros.append(read_pkg_metadata(stubs_path or path, dist_name=dist_name or None))
 
         res = await asyncio.gather(*coros)
         configs: dict[TypeCheckerName, TypeCheckerConfigDict] = res[0]

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -134,3 +134,60 @@ class TestReadPkgMetadata:
             "Source, https://github.com/example/pkg",
             "Bug Tracker, https://github.com/example/pkg/issues",
         ]
+
+    async def test_dist_name_selects_correct_dist_info(self, tmp_path: Path) -> None:
+        """When multiple .dist-info dirs exist, `dist_name` picks the right one."""
+        wrong = tmp_path / "other_pkg-2.0.0.dist-info"
+        wrong.mkdir()
+        (wrong / "METADATA").write_text(
+            textwrap.dedent("""\
+                Metadata-Version: 2.1
+                Name: other-pkg
+                Version: 2.0.0
+            """),
+        )
+        correct = tmp_path / "my_package-1.0.0.dist-info"
+        correct.mkdir()
+        (correct / "METADATA").write_text(
+            textwrap.dedent("""\
+                Metadata-Version: 2.1
+                Name: my-package
+                Version: 1.0.0
+            """),
+        )
+
+        result = await read_pkg_metadata(tmp_path, dist_name="my-package")
+        assert result is not None
+        assert result["Name"] == ["my-package"]
+        assert result["Version"] == ["1.0.0"]
+
+    async def test_dist_name_no_match_returns_none(self, tmp_path: Path) -> None:
+        """When `dist_name` does not match any .dist-info, return None."""
+        wrong = tmp_path / "other_pkg-1.0.0.dist-info"
+        wrong.mkdir()
+        (wrong / "METADATA").write_text(
+            textwrap.dedent("""\
+                Metadata-Version: 2.1
+                Name: other-pkg
+                Version: 1.0.0
+            """),
+        )
+
+        result = await read_pkg_metadata(tmp_path, dist_name="my-package")
+        assert result is None
+
+    async def test_dist_name_normalization(self, tmp_path: Path) -> None:
+        """dist_name matching normalizes hyphens, underscores, and case."""
+        dist_info = tmp_path / "Scipy_Stubs-1.0.0.dist-info"
+        dist_info.mkdir()
+        (dist_info / "METADATA").write_text(
+            textwrap.dedent("""\
+                Metadata-Version: 2.1
+                Name: scipy-stubs
+                Version: 1.0.0
+            """),
+        )
+
+        result = await read_pkg_metadata(tmp_path, dist_name="scipy-stubs")
+        assert result is not None
+        assert result["Name"] == ["scipy-stubs"]


### PR DESCRIPTION
this only affected `typestats check`, not `typestats collect`, so we don't need to rebuild everything.