### PR TITLE
avoid traversing irrelevant cst nodes

### DIFF
--- a/src/typestats/analyze.py
+++ b/src/typestats/analyze.py
@@ -1003,7 +1003,8 @@ class _SymbolVisitor(cst.CSTVisitor):  # noqa: PLR0904
     def _visit_container(self, node: _Container) -> bool:
         if node in self._is_assigned_export:
             self._in_assigned_export.add(node)
-        return True
+            return True
+        return False
 
     @override
     def visit_List(self, node: cst.List) -> bool:
@@ -1016,6 +1017,14 @@ class _SymbolVisitor(cst.CSTVisitor):  # noqa: PLR0904
     @override
     def visit_Set(self, node: cst.Set) -> bool:
         return self._visit_container(node)
+
+    @override
+    def visit_Dict(self, node: cst.Dict) -> bool:
+        return False
+
+    @override
+    def visit_Lambda(self, node: cst.Lambda) -> bool:
+        return False
 
     def _leave_container(self, node: _Container) -> None:
         self._is_assigned_export.discard(node)

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -41,7 +41,6 @@ class TestEmptySource:
 
 class TestRecursionError:
     def test_deeply_nested_source_returns_empty(self) -> None:
-        """Deeply nested expressions should not crash; return empty symbols."""
         from unittest.mock import patch  # noqa: PLC0415
 
         source = "x = 1"
@@ -49,6 +48,37 @@ class TestRecursionError:
             result = collect_symbols(source)
         assert result.symbols == ()
         assert result.type_aliases == ()
+
+    def test_deeply_nested_dict_does_not_recurse(self) -> None:
+        depth = 200
+        inner = "1"
+        for _ in range(depth):
+            inner = f"{{'k': {inner}}}"
+        source = f"X = {inner}\n"
+        result = collect_symbols(source)
+        assert len(result.symbols) == 1
+        assert result.symbols[0].name == "X"
+        assert result.symbols[0].type_ is IMPLICIT
+
+    def test_deeply_nested_list_does_not_recurse(self) -> None:
+        depth = 200
+        inner = "1"
+        for _ in range(depth):
+            inner = f"[{inner}]"
+        source = f"X = {inner}\n"
+        result = collect_symbols(source)
+        assert len(result.symbols) == 1
+        assert result.symbols[0].name == "X"
+
+    def test_deeply_nested_lambda_does_not_recurse(self) -> None:
+        depth = 200
+        inner = "1"
+        for _ in range(depth):
+            inner = f"lambda: {inner}"
+        source = f"X = {inner}\n"
+        result = collect_symbols(source)
+        assert len(result.symbols) == 1
+        assert result.symbols[0].name == "X"
 
 
 class TestParserSyntaxError:


### PR DESCRIPTION
This should help speed things up a bit, and fixes hitting the recursion depth in `sympy.polys.numbersfields.subfield` ([src](https://github.com/sympy/sympy/blob/sympy-1.14.0/sympy/polys/numberfields/subfield.py)).
This won't change the indexing behavior of symbols at all.