### PR TITLE
delist `plotly-stubs`

### DIFF
--- a/packages/typestats-site/projects.toml
+++ b/packages/typestats-site/projects.toml
@@ -115,7 +115,7 @@ projects = [
   { "name" = "click-log" },
   { "name" = "types-click-log" },
   { "name" = "plotly" },
-  { "name" = "plotly-stubs" },
+  # { "name" = "plotly-stubs" },  # installation issue due to mismatching version numbers
   { "name" = "spacy" },
   { "name" = "numba", "exclude" = ["numba/cloudpickle/**"] },
   { "name" = "openai" },


### PR DESCRIPTION
Its version number does not match plotly, so typestats cannot determine the correct version to install. It doesn't seem like it's used a lot (10 gh stars atm) and at first glance looks a lot like raw stubgen output, so it's fine to ignore it I suppose.