### PR TITLE
increase `collect` workflow timeout

### DIFF
--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   collect:
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 240
     environment: reports
     steps:
       - name: checkout main


### PR DESCRIPTION
2 hours isn't enough anymore apparently :(
https://github.com/jorenham/typestats/actions/runs/23580806023/job/68663074350#step:5:10362