### PR TITLE
un-exclude `numba.core`

### DIFF
--- a/packages/typestats-site/projects.toml
+++ b/packages/typestats-site/projects.toml
@@ -117,7 +117,7 @@ projects = [
   { "name" = "plotly" },
   # { "name" = "plotly-stubs" },  # installation issue due to mismatching version numbers
   { "name" = "spacy" },
-  { "name" = "numba", "exclude" = ["numba/cloudpickle/**", "numba/core/**", "numba/cpython/**", "numba/misc/**", "numba/np/**", "numba/parfors/**", "numba/scripts/**", "numba/testing/**"] },
+  { "name" = "numba", "exclude" = ["numba/cloudpickle/**", "numba/cpython/**", "numba/misc/**", "numba/np/**", "numba/parfors/**", "numba/scripts/**", "numba/testing/**"] },
   { "name" = "llvmlite" },
   { "name" = "openai" },
   { "name" = "uvloop" },


### PR DESCRIPTION
Because that's where the important bits live, e.g. `numba.core.decorators.jit`.