### PR TITLE
fix : ignore return type of `__post_init__` in dataclasses

### DIFF
--- a/src/typestats/analyze.py
+++ b/src/typestats/analyze.py
@@ -626,7 +626,7 @@ def is_public_name(name: str) -> bool:
     return not name.startswith("_") or name.endswith("__")
 
 
-_INIT_METHODS: Final = frozenset({"__init__", "__new__", "__post_init__"})
+_INIT_METHODS: Final = frozenset({"__init__", "__new__"})
 _DESCRIPTOR_WRAPPERS: Final = frozenset({"staticmethod", "classmethod"})
 
 

--- a/src/typestats/analyze.py
+++ b/src/typestats/analyze.py
@@ -626,7 +626,7 @@ def is_public_name(name: str) -> bool:
     return not name.startswith("_") or name.endswith("__")
 
 
-_INIT_METHODS: Final = frozenset({"__init__", "__new__"})
+_INIT_METHODS: Final = frozenset({"__init__", "__new__", "__post_init__"})
 _DESCRIPTOR_WRAPPERS: Final = frozenset({"staticmethod", "classmethod"})
 
 
@@ -636,6 +636,7 @@ _RETURN: Final = -1
 _IMPLICIT_DUNDER_METHODS: Final[dict[str, set[int]]] = {
     "__init__": {_RETURN},
     "__init_subclass__": {_RETURN},
+    "__post_init__": {_RETURN},
     "__del__": {_RETURN},
     "__bool__": {_RETURN},
     "__int__": {_RETURN},

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -2170,6 +2170,7 @@ class TestInstanceAttrs:  # noqa: PLR0904
         members = {m.name: m.type_ for m in cls.members}
         assert "C.computed" in members
         assert members["C.computed"] is UNTYPED
+        assert members.get("C.__post_init__") is None
 
     def test_nested_function_ignored(self) -> None:
         src = textwrap.dedent("""\

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -2665,6 +2665,14 @@ class TestTrivialDunderMethods:
         # x: int is 1 typed slot, return is IMPLICIT (skipped), total typable = 1
         assert type_counts(func) == (1, 0, 1)
 
+    def test_post_init_return_implicit(self) -> None:
+        """__post_init__ without return annotation gets IMPLICIT return."""
+        src = "class C:\n    def __post_init__(self): ..."
+        module = collect_symbols(src)
+        func = next(s.type_ for s in module.symbols if s.name == "C.__post_init__")
+        assert isinstance(func, Function)
+        assert func.overloads[0].returns is IMPLICIT
+
 
 class TestTrivialDunderAttrs:
     """Trivial dunder attributes in class bodies are marked IMPLICIT."""

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -2170,7 +2170,6 @@ class TestInstanceAttrs:  # noqa: PLR0904
         members = {m.name: m.type_ for m in cls.members}
         assert "C.computed" in members
         assert members["C.computed"] is UNTYPED
-        assert members.get("C.__post_init__") is None
 
     def test_nested_function_ignored(self) -> None:
         src = textwrap.dedent("""\


### PR DESCRIPTION
#391 