### PR TITLE
try install without `--no-deps`

### DIFF
--- a/packages/typestats-site/src/typestats_site/_uv.py
+++ b/packages/typestats-site/src/typestats_site/_uv.py
@@ -1,5 +1,7 @@
+import logging
 import os
 import shutil
+import subprocess
 from typing import Final
 
 import anyio
@@ -7,6 +9,8 @@ import anyio.to_thread
 
 from typestats._type import StrPath
 from typestats.subprocess import run as _subprocess_run
+
+_logger: Final = logging.getLogger(__name__)
 
 __all__ = (
     "PYTHON_VERSION",
@@ -43,17 +47,21 @@ async def create_venv(path: StrPath, /) -> anyio.Path:
 
 
 async def install(python: StrPath, project: str, version: str, /) -> None:
-    await _subprocess_run(
+    base_args = (
         "uv",
         "pip",
         "install",
-        "--no-deps",
         "--no-config",
         "--no-cache",
         "--python",
         str(anyio.Path(python)),
-        f"{project}=={version}",
     )
+    spec = f"{project}=={version}"
+    try:
+        await _subprocess_run(*base_args, spec)
+    except subprocess.CalledProcessError:
+        _logger.warning("deps install failed for %s; retrying --no-deps", spec)
+        await _subprocess_run(*base_args, "--no-deps", spec)
 
 
 def _venv_path(work_dir: StrPath, project: str, version: str, /) -> anyio.Path:

--- a/packages/typestats-site/tests/test_uv.py
+++ b/packages/typestats-site/tests/test_uv.py
@@ -67,7 +67,7 @@ class TestCreateVenv:
 class TestInstall:
     pytestmark = pytest.mark.anyio
 
-    async def test_runs_uv_pip_install(
+    async def test_installs_with_deps(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
@@ -83,9 +83,53 @@ class TestInstall:
         mock.assert_awaited_once()
         args = mock.call_args[0][0]
         assert args[0] == "uv"
-        assert "--no-deps" in args
+        assert "--no-deps" not in args
+        assert "--no-cache" in args
         assert f"--python={python}" in args or str(python) in args
         assert "mypkg==1.0.0" in args
+
+    async def test_falls_back_to_no_deps(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        mock = AsyncMock(
+            side_effect=[
+                subprocess.CompletedProcess(args=[], returncode=1, stderr=b"boom"),
+                subprocess.CompletedProcess(args=[], returncode=0),
+            ],
+        )
+        monkeypatch.setattr("anyio.run_process", mock)
+
+        python = tmp_path / "venv" / "bin" / "python"
+        await install(python, "mypkg", "1.0.0")
+
+        assert mock.await_count == 2
+        first_args = mock.call_args_list[0][0][0]
+        second_args = mock.call_args_list[1][0][0]
+        assert "--no-deps" not in first_args
+        assert "--no-deps" in second_args
+        assert "mypkg==1.0.0" in second_args
+
+    async def test_reraises_when_no_deps_also_fails(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        mock = AsyncMock(
+            return_value=subprocess.CompletedProcess(
+                args=[],
+                returncode=1,
+                stderr=b"boom",
+            ),
+        )
+        monkeypatch.setattr("anyio.run_process", mock)
+
+        python = tmp_path / "venv" / "bin" / "python"
+        with pytest.raises(subprocess.CalledProcessError):
+            await install(python, "mypkg", "1.0.0")
+
+        assert mock.await_count == 2
 
 
 class TestSitePackagesDir:


### PR DESCRIPTION
this works around `pyrefly coverage` reporting unknown symbols from unavailable deps as `Any`, lowering the strict coverage