### PR TITLE
per-project configurable `--no-deps`

### DIFF
--- a/packages/typestats-site/projects.toml
+++ b/packages/typestats-site/projects.toml
@@ -188,12 +188,15 @@ name = "jsonpickle"
 
 [[projects]]
 name = "torch"
+no_deps = true
 
 [[projects]]
 name = "torchmetrics"
+no_deps = true
 
 [[projects]]
 name = "vLLM"
+no_deps = true
 
 [[projects]]
 name = "tabulate"
@@ -266,6 +269,7 @@ exclude = [
 
 [[projects]]
 name = "timm"
+no_deps = true
 
 [[projects]]
 name = "xgboost"
@@ -275,6 +279,7 @@ name = "dill"
 
 [[projects]]
 name = "kornia"
+no_deps = true
 
 [[projects]]
 name = "mercantile"
@@ -303,6 +308,7 @@ name = "types-pexpect"
 
 [[projects]]
 name = "lpips"
+no_deps = true
 
 [[projects]]
 name = "more-itertools"
@@ -519,6 +525,7 @@ name = "structlog"
 
 [[projects]]
 name = "deepspeed"
+no_deps = true
 
 [[projects]]
 name = "openexr"
@@ -661,6 +668,7 @@ name = "beautifulsoup4"
 
 [[projects]]
 name = "k-diffusion"
+no_deps = true
 
 [[projects]]
 name = "pydantic"

--- a/packages/typestats-site/src/typestats_site/_uv.py
+++ b/packages/typestats-site/src/typestats_site/_uv.py
@@ -46,7 +46,14 @@ async def create_venv(path: StrPath, /) -> anyio.Path:
     return path / "bin" / "python"
 
 
-async def install(python: StrPath, project: str, version: str, /) -> None:
+async def install(
+    python: StrPath,
+    project: str,
+    version: str,
+    /,
+    *,
+    no_deps: bool = False,
+) -> None:
     base_args = (
         "uv",
         "pip",
@@ -57,11 +64,14 @@ async def install(python: StrPath, project: str, version: str, /) -> None:
         str(anyio.Path(python)),
     )
     spec = f"{project}=={version}"
-    try:
-        await _subprocess_run(*base_args, spec)
-    except subprocess.CalledProcessError:
-        _logger.warning("deps install failed for %s; retrying --no-deps", spec)
-        await _subprocess_run(*base_args, "--no-deps", spec)
+    if not no_deps:
+        try:
+            await _subprocess_run(*base_args, spec)
+        except subprocess.CalledProcessError:
+            _logger.warning("deps install failed for %s; retrying --no-deps", spec)
+        else:
+            return
+    await _subprocess_run(*base_args, "--no-deps", spec)
 
 
 def _venv_path(work_dir: StrPath, project: str, version: str, /) -> anyio.Path:
@@ -73,6 +83,8 @@ async def install_to_venv(
     project: str,
     version: str,
     /,
+    *,
+    no_deps: bool = False,
 ) -> anyio.Path:
     """Create a venv, install *project*, and return the `site-packages` path."""
     venv_path = _venv_path(work_dir, project, version)
@@ -81,7 +93,7 @@ async def install_to_venv(
     async with lock:
         if not await venv_path.is_dir():
             python = await create_venv(venv_path)
-            await install(python, project, version)
+            await install(python, project, version, no_deps=no_deps)
         return await site_packages_dir(venv_path)
 
 

--- a/packages/typestats-site/src/typestats_site/collect.py
+++ b/packages/typestats-site/src/typestats_site/collect.py
@@ -94,7 +94,9 @@ class _ProjectCollector:
         project = self.project
 
         try:
-            sp = await install_to_venv(self.work_dir, project.name, str(version))
+            sp = await install_to_venv(
+                self.work_dir, project.name, str(version), no_deps=project.no_deps
+            )
         except subprocess.CalledProcessError:
             _logger.warning("install failed, skipping")
             return False
@@ -126,7 +128,9 @@ class _ProjectCollector:
             base_ver_str = str(base_ver)
             base_sp = self.base_install_cache.get(base_ver_str)
             if base_sp is None:
-                base_sp = await install_to_venv(self.work_dir, base_name, base_ver_str)
+                base_sp = await install_to_venv(
+                    self.work_dir, base_name, base_ver_str, no_deps=project.no_deps
+                )
                 self.base_install_cache[base_ver_str] = base_sp
 
             report = await PackageReport.from_path(

--- a/packages/typestats-site/src/typestats_site/from_project.py
+++ b/packages/typestats-site/src/typestats_site/from_project.py
@@ -39,7 +39,9 @@ async def from_project(
         RuntimeError: If no matching base package version can be found.
     """
     ver, dist_file = await _pypi.latest_distribution(client, project.name)
-    sp = await _uv.install_to_venv(out_dir, project.name, str(ver))
+    sp = await _uv.install_to_venv(
+        out_dir, project.name, str(ver), no_deps=project.no_deps
+    )
     base_name = stubs_base_name(project.name)
 
     # e.g. boto3-stubs-lite ships a boto3-stubs/ directory
@@ -59,7 +61,9 @@ async def from_project(
             prefix = ".".join(str(c) for c in ver.release[:2])
             msg = f"no {base_name} version matching {prefix}.* found"
             raise RuntimeError(msg)
-        base_sp = await _uv.install_to_venv(out_dir, base_name, str(base_ver))
+        base_sp = await _uv.install_to_venv(
+            out_dir, base_name, str(base_ver), no_deps=project.no_deps
+        )
 
         return await PackageReport.from_path(
             base_name,

--- a/packages/typestats-site/tests/test_collect.py
+++ b/packages/typestats-site/tests/test_collect.py
@@ -183,7 +183,7 @@ class TestCollectProject:
             json=_pypi_detail_json(name, version),
         )
 
-        async def _fail(*_args: object) -> Never:  # noqa: RUF029
+        async def _fail(*_args: object, **_kwargs: object) -> Never:  # noqa: RUF029
             raise subprocess.CalledProcessError(1, ["uv", "pip", "install"])
 
         monkeypatch.setattr("typestats_site.collect.install_to_venv", _fail)

--- a/packages/typestats-site/tests/test_uv.py
+++ b/packages/typestats-site/tests/test_uv.py
@@ -88,6 +88,24 @@ class TestInstall:
         assert f"--python={python}" in args or str(python) in args
         assert "mypkg==1.0.0" in args
 
+    async def test_no_deps_skips_dep_resolution(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        mock = AsyncMock(
+            return_value=subprocess.CompletedProcess(args=[], returncode=0),
+        )
+        monkeypatch.setattr("anyio.run_process", mock)
+
+        python = tmp_path / "venv" / "bin" / "python"
+        await install(python, "mypkg", "1.0.0", no_deps=True)
+
+        mock.assert_awaited_once()
+        args = mock.call_args[0][0]
+        assert "--no-deps" in args
+        assert "mypkg==1.0.0" in args
+
     async def test_falls_back_to_no_deps(
         self,
         tmp_path: Path,

--- a/src/typestats/_testing.py
+++ b/src/typestats/_testing.py
@@ -24,6 +24,7 @@ def mock_uv_factory(
             work_dir: anyio.Path,
             project: str,
             version: str,
+            **_kwargs: object,
         ) -> anyio.Path:
             sp = anyio.Path(work_dir) / f"{project}-{version}" / "site-packages"
             await sp.mkdir(parents=True, exist_ok=True)

--- a/src/typestats/projects.py
+++ b/src/typestats/projects.py
@@ -14,6 +14,7 @@ class Project(BaseModel):
 
     name: str
     exclude: tuple[str, ...] = Field(default=())
+    no_deps: bool = False
 
 
 def load_projects(path: StrPath) -> list[Project]:

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -18,6 +18,12 @@ class TestProject:
         assert p.name == "numpy"
         assert p.exclude == ("tests/**", "benchmarks/**")
 
+    def test_no_deps_default(self) -> None:
+        assert Project(name="pandas").no_deps is False
+
+    def test_with_no_deps(self) -> None:
+        assert Project(name="torch", no_deps=True).no_deps is True
+
     def test_frozen(self) -> None:
         p = Project(name="numpy")
         with pytest.raises(ValidationError):
@@ -41,6 +47,11 @@ projects = [
         assert len(projects) == 2
         assert projects[0] == Project(name="numpy", exclude=("numpy/typing/tests/**",))
         assert projects[1] == Project(name="scipy-stubs")
+
+    def test_load_no_deps(self, tmp_path: Path) -> None:
+        toml_path = tmp_path / "projects.toml"
+        toml_path.write_text('[[projects]]\nname = "torch"\nno_deps = true\n')
+        assert load_projects(toml_path) == [Project(name="torch", no_deps=True)]
 
     def test_empty_projects_list(self, tmp_path: Path) -> None:
         toml_path = tmp_path / "projects.toml"


### PR DESCRIPTION
Because the deps of some huge projects like torch can cause the CI (re)collect jobs to get cancelled because of a full disk.